### PR TITLE
Cleaned up install script, added to documentation and made compatible for Ubuntu Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This package uses the [`remembrance-agent` engine package](https://github.com/re
 
 ![Logo](./docs/img/logo.png)
 
+## Installation Requirements
+
+### Debian-Based Systems (Ubuntu)
+
+System Packages:
+
+- openjdk-8-jdk
+
+
 ## Commands
 
 ### Building
@@ -27,8 +36,15 @@ sudo VERSION="2.0.0" bash ./bin/install
 ```
 
 Now you can run the following from anywhere:
+
 ```bash
 VERSION="2.0.0" ra --home $HOME
+```
+
+or with the alias that was added into your .bashrc file:
+
+```bash
+ra
 ```
 
 ### Running (cross platform)

--- a/bin/install
+++ b/bin/install
@@ -25,4 +25,9 @@ sudo chmod +x ${EXECUTABLE}
 echo ">>> COPYING PLIST TO INSTALL DIRECTORY"
 cp ${PLIST} ${INSTALL_DIR}
 
+
 echo ">>> INSTALLED"
+echo "alias ra=\"VERSION=\"2.0.0\" ra --home \$HOME\"" >> ~/.bashrc
+echo ">>> ALIAS CREATED IN ~/.bashrc"
+echo ">>> SOURCE ~/.bashrc AND INVOKE ALIAS BY RUNNING \"ra\""
+echo ">>> IN YOUR COMMAND LINE"


### PR DESCRIPTION
Hey @p13i 

I added more documentation to the README to account for Ubuntu Linux. A package requirement was not included which is necessary to execute the agent. 

I also added an alias you could create in the install script called `ra` which allows you to easily execute the agent from anywhere. 

Let me know your thoughts.

~ TheCedarPrince